### PR TITLE
Fix backend host on local

### DIFF
--- a/project/apps/api-gateway/.env.example
+++ b/project/apps/api-gateway/.env.example
@@ -1,2 +1,3 @@
+NODE_ENV=development
 SUPABASE_URL=your-supabase-url
 SUPABASE_KEY=your-supabase-key

--- a/project/apps/api-gateway/src/api-gateway.module.ts
+++ b/project/apps/api-gateway/src/api-gateway.module.ts
@@ -25,7 +25,7 @@ import { LoggerModule } from 'nestjs-pino';
         name: 'QUESTION_SERVICE',
         transport: Transport.TCP,
         options: {
-          host: process.env.QUESTION_SERVICE_HOST || 'question-service',
+          host: process.env.QUESTION_SERVICE_HOST || 'localhost',
           port: 3001,
         },
       },

--- a/project/apps/api-gateway/src/api-gateway.module.ts
+++ b/project/apps/api-gateway/src/api-gateway.module.ts
@@ -25,7 +25,10 @@ import { LoggerModule } from 'nestjs-pino';
         name: 'QUESTION_SERVICE',
         transport: Transport.TCP,
         options: {
-          host: process.env.QUESTION_SERVICE_HOST || 'localhost',
+          host:
+            process.env.NODE_ENV === 'development'
+              ? 'localhost'
+              : process.env.QUESTION_SERVICE_HOST || 'localhost',
           port: 3001,
         },
       },

--- a/project/apps/question-service/.env.example
+++ b/project/apps/question-service/.env.example
@@ -1,2 +1,3 @@
+NODE_ENV=development
 SUPABASE_URL=your-supabase-url
 SUPABASE_KEY=your-supabase-key

--- a/project/apps/question-service/src/main.ts
+++ b/project/apps/question-service/src/main.ts
@@ -8,7 +8,7 @@ async function bootstrap() {
     {
       transport: Transport.TCP,
       options: {
-        host: process.env.QUESTION_SERVICE_HOST || 'question-service',
+        host: process.env.QUESTION_SERVICE_HOST || 'localhost',
         port: 3001,
       },
     },

--- a/project/apps/question-service/src/main.ts
+++ b/project/apps/question-service/src/main.ts
@@ -8,7 +8,10 @@ async function bootstrap() {
     {
       transport: Transport.TCP,
       options: {
-        host: process.env.QUESTION_SERVICE_HOST || 'localhost',
+        host:
+          process.env.NODE_ENV === 'development'
+            ? 'localhost'
+            : process.env.QUESTION_SERVICE_HOST || 'localhost',
         port: 3001,
       },
     },


### PR DESCRIPTION
- Host name on local should be `localhost`
- On docker, it should be the name of the service we defined in `docker-compose.yaml` as that allows docker to resolve the host to the correct container.