### PR TITLE
Add Role Guard to endpoints

### DIFF
--- a/project/apps/api-gateway/src/questions/questions.controller.ts
+++ b/project/apps/api-gateway/src/questions/questions.controller.ts
@@ -13,8 +13,10 @@ import {
   Query,
   UsePipes,
   BadRequestException,
+  UseGuards,
 } from '@nestjs/common';
 import { ClientProxy } from '@nestjs/microservices';
+import { ROLE } from '@repo/dtos/generated/enums/auth.enums';
 // import { AuthGuard } from 'src/auth/auth.guard';
 import {
   CreateQuestionDto,
@@ -25,9 +27,12 @@ import {
   updateQuestionSchema,
 } from '@repo/dtos/questions';
 import { ZodValidationPipe } from '@repo/pipes/zod-validation-pipe.pipe';
+import { AuthGuard } from 'src/auth/auth.guard';
+import { Roles } from 'src/roles/roles.decorator';
+import { RolesGuard } from 'src/roles/roles.guard';
 
 @Controller('questions')
-// @UseGuards(AuthGuard) // comment out if we dw auth for now
+@UseGuards(AuthGuard, RolesGuard) // comment out if we dw auth for now
 export class QuestionsController {
   constructor(
     @Inject('QUESTION_SERVICE')
@@ -35,6 +40,7 @@ export class QuestionsController {
   ) {}
 
   @Get()
+  @Roles(ROLE.User)
   @UsePipes(new ZodValidationPipe(questionFiltersSchema))
   async getQuestions(@Query() filters: QuestionFiltersDto) {
     return this.questionsServiceClient.send({ cmd: 'get_questions' }, filters);

--- a/project/apps/api-gateway/src/questions/questions.controller.ts
+++ b/project/apps/api-gateway/src/questions/questions.controller.ts
@@ -1,23 +1,24 @@
 // apps/backend/api-gateway/src/questions/questions.controller.ts
 
 import {
-  Controller,
-  Get,
-  Param,
-  Inject,
+  BadRequestException,
   Body,
+  Controller,
+  Delete,
+  Get,
+  Inject,
+  Param,
   Post,
   // UseGuards,
   Put,
-  Delete,
   Query,
   UsePipes,
-  BadRequestException,
-  UseGuards,
 } from '@nestjs/common';
 import { ClientProxy } from '@nestjs/microservices';
-import { ROLE } from '@repo/dtos/generated/enums/auth.enums';
 // import { AuthGuard } from 'src/auth/auth.guard';
+// import { RolesGuard } from 'src/roles/roles.guard';
+// import { Roles } from 'src/roles/roles.decorator';
+// import { ROLE } from '@repo/dtos/generated/enums/auth.enums';
 import {
   CreateQuestionDto,
   createQuestionSchema,
@@ -27,12 +28,9 @@ import {
   updateQuestionSchema,
 } from '@repo/dtos/questions';
 import { ZodValidationPipe } from '@repo/pipes/zod-validation-pipe.pipe';
-import { AuthGuard } from 'src/auth/auth.guard';
-import { Roles } from 'src/roles/roles.decorator';
-import { RolesGuard } from 'src/roles/roles.guard';
 
 @Controller('questions')
-@UseGuards(AuthGuard, RolesGuard) // comment out if we dw auth for now
+// @UseGuards(AuthGuard, RolesGuard) // comment out if we dw auth for now
 export class QuestionsController {
   constructor(
     @Inject('QUESTION_SERVICE')
@@ -40,7 +38,7 @@ export class QuestionsController {
   ) {}
 
   @Get()
-  @Roles(ROLE.User)
+  // @Roles(ROLE.User)
   @UsePipes(new ZodValidationPipe(questionFiltersSchema))
   async getQuestions(@Query() filters: QuestionFiltersDto) {
     return this.questionsServiceClient.send({ cmd: 'get_questions' }, filters);

--- a/project/apps/api-gateway/src/roles/roles.decorator.ts
+++ b/project/apps/api-gateway/src/roles/roles.decorator.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from '@nestjs/common';
+import { ROLE } from '@repo/dtos/generated/enums/auth.enums';
+
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: ROLE[]) => SetMetadata(ROLES_KEY, roles);

--- a/project/apps/api-gateway/src/roles/roles.guard.ts
+++ b/project/apps/api-gateway/src/roles/roles.guard.ts
@@ -1,0 +1,33 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { ROLE } from '@repo/dtos/generated/enums/auth.enums';
+import { ROLES_KEY } from './roles.decorator';
+
+// Must be used in conjunction with AuthGuard, so that the user will be populated with role
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<ROLE[]>(ROLES_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (!requiredRoles) {
+      return true;
+    }
+    const { user } = context.switchToHttp().getRequest();
+    if (requiredRoles.some((role) => user.role == role)) {
+      return true;
+    } else {
+      throw new ForbiddenException(
+        'You do not have permission for this resource',
+      );
+    }
+  }
+}


### PR DESCRIPTION
# What is this PR doing?
- Adds `RolesGuard` to allow us to control which roles get access to a specific endpoint
- `RolesGuard` has to be used in conjunction with `AuthGuard` in order for the `request.user` to be populated with the correct role
- Use `@Roles(ROLE.User)` to specify what roles should be allowed for an endpoint, see `questions.controller.ts` for example

Note: We do not combine this with `AuthGuard` to ensure **SRP**, quote from [nestjs docs](https://docs.nestjs.com/security/authorization): 
> Authorization is orthogonal and independent from authentication. However, authorization requires an authentication mechanism.

