### PR TITLE
Fix issue of microservices starting twice

### DIFF
--- a/project/apps/auth-service/src/main.ts
+++ b/project/apps/auth-service/src/main.ts
@@ -4,24 +4,21 @@ import { AuthModule } from './auth.module';
 import { EnvService } from './env/env.service';
 
 async function bootstrap() {
-  const appContext = await NestFactory.createApplicationContext(AuthModule);
-  const envService = appContext.get(EnvService);
+  const app = await NestFactory.create(AuthModule);
+  const envService = app.get(EnvService);
   const NODE_ENV = envService.get('NODE_ENV');
   const AUTH_SERVICE_HOST = envService.get('AUTH_SERVICE_HOST');
-  appContext.close();
 
   const host = NODE_ENV === 'development' ? 'localhost' : AUTH_SERVICE_HOST;
-  const app = await NestFactory.createMicroservice<MicroserviceOptions>(
-    AuthModule,
-    {
-      transport: Transport.TCP,
-      options: {
-        host: host,
-        port: 3003,
-      },
+  app.connectMicroservice<MicroserviceOptions>({
+    transport: Transport.TCP,
+    options: {
+      host: host,
+      port: 3003,
     },
-  );
-  await app.listen();
+  });
+  await app.startAllMicroservices();
+  await app.listen(3003);
   console.log(`Auth Service is listening on ${host}:3003`);
 }
 bootstrap();

--- a/project/apps/matching-service/src/main.ts
+++ b/project/apps/matching-service/src/main.ts
@@ -4,25 +4,21 @@ import { EnvService } from './env/env.service';
 import { MatchingModule } from './matching.module';
 
 async function bootstrap() {
-  const appContext = await NestFactory.createApplicationContext(MatchingModule);
-  const envService = appContext.get(EnvService);
+  const app = await NestFactory.create(MatchingModule);
+  const envService = app.get(EnvService);
   const NODE_ENV = envService.get('NODE_ENV');
   const MATCHING_SERVICE_HOST = envService.get('MATCHING_SERVICE_HOST');
-  appContext.close();
 
   const host = NODE_ENV === 'development' ? 'localhost' : MATCHING_SERVICE_HOST;
-  const app = await NestFactory.createMicroservice<MicroserviceOptions>(
-    MatchingModule,
-    {
-      transport: Transport.TCP,
-      options: {
-        host: host,
-        port: 3004,
-      },
+  app.connectMicroservice<MicroserviceOptions>({
+    transport: Transport.TCP,
+    options: {
+      host: host,
+      port: 3004,
     },
-  );
-
-  await app.listen();
+  });
+  await app.startAllMicroservices();
+  await app.listen(3004);
   console.log(`Matching Service is listening on ${host}:3004`);
 }
 bootstrap();

--- a/project/apps/question-service/src/main.ts
+++ b/project/apps/question-service/src/main.ts
@@ -4,25 +4,21 @@ import { EnvService } from './env/env.service';
 import { QuestionsModule } from './questions.module';
 
 async function bootstrap() {
-  const appContext =
-    await NestFactory.createApplicationContext(QuestionsModule);
-  const envService = appContext.get(EnvService);
+  const app = await NestFactory.create(QuestionsModule);
+  const envService = app.get(EnvService);
   const NODE_ENV = envService.get('NODE_ENV');
   const QUESTION_SERVICE_HOST = envService.get('QUESTION_SERVICE_HOST');
-  appContext.close();
 
   const host = NODE_ENV === 'development' ? 'localhost' : QUESTION_SERVICE_HOST;
-  const app = await NestFactory.createMicroservice<MicroserviceOptions>(
-    QuestionsModule,
-    {
-      transport: Transport.TCP,
-      options: {
-        host: host,
-        port: 3001,
-      },
+  app.connectMicroservice<MicroserviceOptions>({
+    transport: Transport.TCP,
+    options: {
+      host: host,
+      port: 3001,
     },
-  );
-  await app.listen();
+  });
+  await app.startAllMicroservices();
+  await app.listen(3001);
   console.log(`Question Service is listening on ${host}:3001`);
 }
 bootstrap();

--- a/project/apps/user-service/src/main.ts
+++ b/project/apps/user-service/src/main.ts
@@ -4,24 +4,21 @@ import { EnvService } from './env/env.service';
 import { UsersModule } from './users.module';
 
 async function bootstrap() {
-  const appContext = await NestFactory.createApplicationContext(UsersModule);
-  const envService = appContext.get(EnvService);
+  const app = await NestFactory.create(UsersModule);
+  const envService = app.get(EnvService);
   const NODE_ENV = envService.get('NODE_ENV');
   const USER_SERVICE_HOST = envService.get('USER_SERVICE_HOST');
-  appContext.close();
 
   const host = NODE_ENV === 'development' ? 'localhost' : USER_SERVICE_HOST;
-  const app = await NestFactory.createMicroservice<MicroserviceOptions>(
-    UsersModule,
-    {
-      transport: Transport.TCP,
-      options: {
-        host: host,
-        port: 3002,
-      },
+  app.connectMicroservice<MicroserviceOptions>({
+    transport: Transport.TCP,
+    options: {
+      host: host,
+      port: 3002,
     },
-  );
-  await app.listen();
+  });
+  await app.startAllMicroservices();
+  await app.listen(3002);
   console.log(`User Service is listening on ${host}:3002`);
 }
 bootstrap();


### PR DESCRIPTION
Microservices start twice because of `createApplicationContext`, temp workaround is to make it a hybrid app so we dont have to call the above function to get the env.