### PR TITLE
Fix selectors

### DIFF
--- a/project/apps/web/app/layout.tsx
+++ b/project/apps/web/app/layout.tsx
@@ -33,7 +33,7 @@ const LayoutWithSidebarAndTopbar = ({
   children: React.ReactNode;
 }) => {
   const pathname = usePathname();
-  const { isSearching } = useSocketStore();
+  const isSearching = useSocketStore((state) => state.isSearching);
   const user = useAuthStore.use.user();
   const signOut = useAuthStore.use.signOut();
 
@@ -67,7 +67,8 @@ const RootLayout = ({
 }>) => {
   const pathname = usePathname();
   const fetchUser = useAuthStore.use.fetchUser();
-  const { connect, disconnect } = useSocketStore();
+  const connect = useSocketStore((state) => state.connect);
+  const disconnect = useSocketStore((state) => state.disconnect);
   const excludeLoginStatePaths = ['/login'];
   const shouldEnforceLoginState = !excludeLoginStatePaths.includes(pathname);
 

--- a/project/apps/web/app/page.tsx
+++ b/project/apps/web/app/page.tsx
@@ -14,7 +14,11 @@ import { cancelMatch, createMatch } from '@/lib/api/match';
 import useSocketStore from '@/stores/useSocketStore';
 
 const Dashboard = () => {
-  const { isSearching, startSearch, stopSearch, socket } = useSocketStore();
+  const isSearching = useSocketStore((state) => state.isSearching);
+  const startSearch = useSocketStore((state) => state.startSearch);
+  const stopSearch = useSocketStore((state) => state.stopSearch);
+  const socket = useSocketStore((state) => state.socket);
+
   const [timer, setTimer] = useState(0);
   const [matchReqId, setMatchReqId] = useState<string | null>(null);
   const intervalRef = useRef<number | null>(null);

--- a/project/apps/web/components/auth-wrappers/PublicPageWrapper.tsx
+++ b/project/apps/web/components/auth-wrappers/PublicPageWrapper.tsx
@@ -44,7 +44,7 @@ export const PublicPageWrapper = ({
 
   if (user && redirect.strict) {
     return (
-      <div className="flex w-full h-full items-center justify-center">
+      <div className="flex items-center justify-center w-full h-full">
         Loading...
       </div>
     );

--- a/project/apps/web/stores/useAuthStore.ts
+++ b/project/apps/web/stores/useAuthStore.ts
@@ -1,6 +1,7 @@
 import { SignInDto, SignUpDto } from '@repo/dtos/auth';
 import { UserDataDto } from '@repo/dtos/users';
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 
 import { signUp, signIn, signOut, me } from '@/lib/api/auth';
 import { createSelectors } from '@/lib/zustand';
@@ -13,24 +14,31 @@ interface AuthState {
   fetchUser: () => Promise<void>;
 }
 
-const useAuthStoreBase = create<AuthState>()((set) => ({
-  user: null,
-  signUp: async (signUpDto: SignUpDto) => {
-    const { userData } = await signUp(signUpDto);
-    set({ user: userData });
-  },
-  signIn: async (signInDto: SignInDto) => {
-    const { userData } = await signIn(signInDto);
-    set({ user: userData });
-  },
-  signOut: async () => {
-    await signOut();
-    set({ user: null });
-  },
-  fetchUser: async () => {
-    const userData = await me();
-    set({ user: userData });
-  },
-}));
+export const useAuthStoreBase = create<AuthState>()(
+  persist(
+    (set) => ({
+      user: null,
+      signUp: async (signUpDto: SignUpDto) => {
+        const { userData } = await signUp(signUpDto);
+        set({ user: userData });
+      },
+      signIn: async (signInDto: SignInDto) => {
+        const { userData } = await signIn(signInDto);
+        set({ user: userData });
+      },
+      signOut: async () => {
+        await signOut();
+        set({ user: null });
+      },
+      fetchUser: async () => {
+        const userData = await me();
+        set({ user: userData });
+      },
+    }),
+    {
+      name: 'user-storage', // name of the item in the storage (must be unique)
+    },
+  ),
+);
 
 export const useAuthStore = createSelectors(useAuthStoreBase);


### PR DESCRIPTION
# What is this PR doing
- If we destructure the store, we will cause react to re-render whenever any part of the store changes, instead we should use the selector to only select which part of the store this component is dependent on.
- `useAuthStore` should be persistent, if not we need to keep fetching the user on every render.