### PR TITLE
Fix authentication, refreshing and redirection issues

### DIFF
--- a/project/apps/api-gateway/src/questions/questions.controller.ts
+++ b/project/apps/api-gateway/src/questions/questions.controller.ts
@@ -9,13 +9,13 @@ import {
   Inject,
   Param,
   Post,
-  // UseGuards,
+  UseGuards,
   Put,
   Query,
   UsePipes,
 } from '@nestjs/common';
 import { ClientProxy } from '@nestjs/microservices';
-// import { AuthGuard } from 'src/auth/auth.guard';
+import { AuthGuard } from 'src/auth/auth.guard';
 // import { RolesGuard } from 'src/roles/roles.guard';
 // import { Roles } from 'src/roles/roles.decorator';
 // import { ROLE } from '@repo/dtos/generated/enums/auth.enums';
@@ -30,7 +30,7 @@ import {
 import { ZodValidationPipe } from '@repo/pipes/zod-validation-pipe.pipe';
 
 @Controller('questions')
-// @UseGuards(AuthGuard, RolesGuard) // comment out if we dw auth for now
+@UseGuards(AuthGuard) // add role guard once authorisation is implemented
 export class QuestionsController {
   constructor(
     @Inject('QUESTION_SERVICE')
@@ -38,7 +38,6 @@ export class QuestionsController {
   ) {}
 
   @Get()
-  // @Roles(ROLE.User)
   @UsePipes(new ZodValidationPipe(questionFiltersSchema))
   async getQuestions(@Query() filters: QuestionFiltersDto) {
     return this.questionsServiceClient.send({ cmd: 'get_questions' }, filters);
@@ -50,6 +49,7 @@ export class QuestionsController {
   }
 
   @Post()
+  // @Roles(ROLE.Admin) // comment out since we don't have authorisation for now
   @UsePipes(new ZodValidationPipe(createQuestionSchema))
   async createQuestion(@Body() createQuestionDto: CreateQuestionDto) {
     return this.questionsServiceClient.send(
@@ -59,6 +59,7 @@ export class QuestionsController {
   }
 
   @Put(':id')
+  // @Roles(ROLE.Admin) // comment out since we don't have authorisation for now
   async updateQuestion(
     @Param('id') id: string,
     @Body(new ZodValidationPipe(updateQuestionSchema)) // validation on the body only
@@ -74,6 +75,7 @@ export class QuestionsController {
   }
 
   @Delete(':id')
+  // @Roles(ROLE.Admin) // comment out since we don't have authorisation for now
   async deleteQuestion(@Param('id') id: string) {
     return this.questionsServiceClient.send({ cmd: 'delete_question' }, id);
   }

--- a/project/apps/matching-service/src/db/match.supabase.ts
+++ b/project/apps/matching-service/src/db/match.supabase.ts
@@ -22,7 +22,6 @@ export class MatchSupabase {
   ) {
     const supabaseUrl = this.envService.get('SUPABASE_URL');
     const supabaseKey = this.envService.get('SUPABASE_KEY');
-    console.log(supabaseKey);
     if (!supabaseUrl || !supabaseKey) {
       throw new Error('Supabase URL and key must be provided');
     }

--- a/project/apps/web/app/layout.tsx
+++ b/project/apps/web/app/layout.tsx
@@ -2,7 +2,6 @@
 
 import { Inter, Roboto } from 'next/font/google';
 import { usePathname } from 'next/navigation';
-import { useEffect } from 'react';
 
 import { EnforceLoginStatePageWrapper } from '@/components/auth-wrappers/EnforceLoginStatePageWrapper';
 import ReactQueryProvider from '@/components/ReactQueryProvider';
@@ -63,29 +62,14 @@ const RootLayout = ({
   children: React.ReactNode;
 }>) => {
   const pathname = usePathname();
-  const fetchUser = useAuthStore.use.fetchUser();
-  const shouldEnforceLoginState = !pathname.startsWith('/login');
-
-  // Fetch user data on initial render, ensures logged in user data is available
-  useEffect(() => {
-    const initializeUser = async () => {
-      if (!shouldEnforceLoginState) return;
-
-      try {
-        await fetchUser();
-      } catch (error) {
-        console.error('Failed to fetch user data:', error);
-      }
-    };
-    initializeUser();
-  }, [fetchUser]);
+  const isLoginPage = pathname.startsWith('/login');
 
   return (
     <html lang="en" className={inter.className}>
       <body className={roboto.className}>
         <Suspense fallback={<Skeleton className="w-screen h-screen" />}>
           <ReactQueryProvider>
-            <EnforceLoginStatePageWrapper enabled={shouldEnforceLoginState}>
+            <EnforceLoginStatePageWrapper requireLogin={!isLoginPage}>
               <LayoutWithSidebarAndTopbar>
                 {children}
               </LayoutWithSidebarAndTopbar>

--- a/project/apps/web/app/layout.tsx
+++ b/project/apps/web/app/layout.tsx
@@ -2,6 +2,7 @@
 
 import { Inter, Roboto } from 'next/font/google';
 import { usePathname } from 'next/navigation';
+import { useEffect } from 'react';
 
 import { EnforceLoginStatePageWrapper } from '@/components/auth-wrappers/EnforceLoginStatePageWrapper';
 import ReactQueryProvider from '@/components/ReactQueryProvider';
@@ -62,7 +63,21 @@ const RootLayout = ({
   children: React.ReactNode;
 }>) => {
   const pathname = usePathname();
+  const fetchUser = useAuthStore.use.fetchUser();
   const isLoginPage = pathname.startsWith('/login');
+
+  useEffect(() => {
+    if (isLoginPage) return;
+
+    const initialiseUser = async () => {
+      try {
+        await fetchUser();
+      } catch (error) {
+        console.error('Failed to fetch user data:', error);
+      }
+    };
+    initialiseUser();
+  }, [fetchUser]);
 
   return (
     <html lang="en" className={inter.className}>

--- a/project/apps/web/app/login/SignInForm.tsx
+++ b/project/apps/web/app/login/SignInForm.tsx
@@ -2,7 +2,7 @@
 
 import { signInSchema, SignInDto } from '@repo/dtos/auth';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 
 import { Button } from '@/components/ui/button';
 import {
@@ -31,12 +31,13 @@ export function SignInForm() {
   const queryClient = useQueryClient();
   const signIn = useAuthStore.use.signIn();
   const router = useRouter();
+  const searchParams = useSearchParams();
 
   const mutation = useMutation({
     mutationFn: (values: SignInDto) => signIn(values),
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.Me] });
-      await router.push('/');
+      await router.push(searchParams.get('callbackUrl') || '/');
     },
     onError(error) {
       toast({

--- a/project/apps/web/components/auth-wrappers/EnforceLoginStatePageWrapper.tsx
+++ b/project/apps/web/components/auth-wrappers/EnforceLoginStatePageWrapper.tsx
@@ -19,17 +19,17 @@ const Redirect = ({ requireLogin }: EnforceLoginStatePageWrapperProps) => {
     const { pathname, search, hash } = window.location;
     return encodeURIComponent(`${pathname}${search}${hash}`);
   }, []);
-    
+
   useEffect(() => {
     if (requireLogin) {
       // Redirect to SIGN_IN if not authenticated
       router.replace(`${SIGN_IN}?callbackUrl=${redirectUrlForLogin}`);
     } else {
       // Redirect to LANDING if already authenticated
-      router.replace(LANDING)
+      router.replace(LANDING);
     }
   }, [requireLogin, redirectUrlForLogin, router]);
-  
+
   return <DefaultSkeleton />;
 };
 
@@ -44,11 +44,11 @@ export const EnforceLoginStatePageWrapper = ({
   children,
 }: PropsWithChildren<EnforceLoginStatePageWrapperProps>): React.ReactElement => {
   const user = useAuthStore.use.user();
-  
+
   // Valid conditions for rendering children
-  if (user && requireLogin || !user && !requireLogin) {
+  if ((user && requireLogin) || (!user && !requireLogin)) {
     return <>{children}</>;
   }
-  
+
   return <Redirect requireLogin={requireLogin} />;
 };

--- a/project/apps/web/components/auth-wrappers/EnforceLoginStatePageWrapper.tsx
+++ b/project/apps/web/components/auth-wrappers/EnforceLoginStatePageWrapper.tsx
@@ -3,51 +3,52 @@
 import { useRouter } from 'next/navigation';
 import { type PropsWithChildren, useEffect, useMemo } from 'react';
 
-import { SIGN_IN } from '@/lib/routes';
+import { LANDING, SIGN_IN } from '@/lib/routes';
 import { useAuthStore } from '@/stores/useAuthStore';
 
 import DefaultSkeleton from '../DefaultSkeleton';
 
 interface EnforceLoginStatePageWrapperProps {
-  /**
-   * Route to redirect to when user is not authenticated. Defaults to
-   * `SIGN_IN` route if not provided.
-   */
-  redirectTo?: string;
-  enabled?: boolean;
+  requireLogin: boolean;
 }
 
-const Redirect = ({ redirectTo }: EnforceLoginStatePageWrapperProps) => {
+const Redirect = ({ requireLogin }: EnforceLoginStatePageWrapperProps) => {
   const router = useRouter();
-  const redirectUrl = useMemo(() => {
+  const redirectUrlForLogin = useMemo(() => {
     if (typeof window === 'undefined') return encodeURIComponent('/');
     const { pathname, search, hash } = window.location;
     return encodeURIComponent(`${pathname}${search}${hash}`);
   }, []);
-
+    
   useEffect(() => {
-    void router.replace(`${redirectTo}?callbackUrl=${redirectUrl}`);
-  }, [router, redirectTo, redirectUrl]);
-
+    if (requireLogin) {
+      // Redirect to SIGN_IN if not authenticated
+      router.replace(`${SIGN_IN}?callbackUrl=${redirectUrlForLogin}`);
+    } else {
+      // Redirect to LANDING if already authenticated
+      router.replace(LANDING)
+    }
+  }, [requireLogin, redirectUrlForLogin, router]);
+  
   return <DefaultSkeleton />;
 };
 
 /**
- * Page wrapper that renders children only if the login state localStorage flag has been set.
- * Otherwise, will redirect to the route passed into the `redirectTo` prop.
+ * Page wrapper that renders children only if either user authenticated + requireLogin or user unauthenticated + !requireLogin.
+ * Otherwise, the user will be redirected.
  *
  * @note 🚨 There is no authentication being performed by this component. This component is merely a wrapper that checks for the presence of the login flag in localStorage. This means that a user could add the flag and bypass the check. Any page children that require authentication should also perform authentication checks in that page itself!
  */
 export const EnforceLoginStatePageWrapper = ({
-  redirectTo = SIGN_IN,
-  enabled = true,
+  requireLogin,
   children,
 }: PropsWithChildren<EnforceLoginStatePageWrapperProps>): React.ReactElement => {
   const user = useAuthStore.use.user();
-
-  if (user || !enabled) {
+  
+  // Valid conditions for rendering children
+  if (user && requireLogin || !user && !requireLogin) {
     return <>{children}</>;
   }
-
-  return <Redirect redirectTo={redirectTo} />;
+  
+  return <Redirect requireLogin={requireLogin} />;
 };

--- a/project/apps/web/components/auth-wrappers/EnforceLoginStatePageWrapper.tsx
+++ b/project/apps/web/components/auth-wrappers/EnforceLoginStatePageWrapper.tsx
@@ -37,7 +37,7 @@ const Redirect = ({ requireLogin }: EnforceLoginStatePageWrapperProps) => {
  * Page wrapper that renders children only if either user authenticated + requireLogin or user unauthenticated + !requireLogin.
  * Otherwise, the user will be redirected.
  *
- * @note 🚨 There is no authentication being performed by this component. This component is merely a wrapper that checks for the presence of the login flag in localStorage. This means that a user could add the flag and bypass the check. Any page children that require authentication should also perform authentication checks in that page itself!
+ * @note 🚨 There is no authentication being performed by this component. This component is merely a wrapper that checks authentication state and redirects if needed. Any page children that require authentication should also perform authentication checks in that page itself!
  */
 export const EnforceLoginStatePageWrapper = ({
   requireLogin,

--- a/project/apps/web/stores/useAuthStore.ts
+++ b/project/apps/web/stores/useAuthStore.ts
@@ -31,8 +31,12 @@ export const useAuthStoreBase = create<AuthState>()(
         set({ user: null });
       },
       fetchUser: async () => {
-        const userData = await me();
-        set({ user: userData });
+        try {
+          set({ user: await me() });
+        } catch {
+          // If user is not authenticated or tokens expired
+          set({ user: null });
+        }
       },
     }),
     {


### PR DESCRIPTION
**Issues Addressed**
- In auth guard, original request cookies not updated correctly, leading to invalid token when trying to call `me` (in fact, any other endpoints too) after auth guard check
- Enforce page wrapper redirection error
- When both access and refresh tokens expire/disappear from local storage, should log user out but does not because local storage still contains user session