### PR TITLE
Fix user delete flow

### DIFF
--- a/project/apps/api-gateway/src/users/users.controller.ts
+++ b/project/apps/api-gateway/src/users/users.controller.ts
@@ -156,14 +156,13 @@ export class UsersController {
       throw new ForbiddenException('Access denied.');
     }
 
-    // Delete user and clear session
+    // Delete user -> automatic session termination on supabase end
     const isDeleted = await firstValueFrom(
       this.usersServiceClient.send({ cmd: 'delete_user' }, id),
     );
 
-    // Sign out user if they are deleting their own account
+    // Clear cookies for user if they are deleting their own account
     if (userData.id == id) {
-      await this.authServiceClient.send({ cmd: 'signout' }, {});
       res.clearCookie('access_token');
       res.clearCookie('refresh_token');
     }

--- a/project/apps/collaboration-service/src/adapters/db/collaboration.supabase.ts
+++ b/project/apps/collaboration-service/src/adapters/db/collaboration.supabase.ts
@@ -349,14 +349,6 @@ export class CollaborationSupabase implements CollaborationRepository {
         );
       }
 
-      if (!user1Data) {
-        throw new NotFoundException(`User with id ${user1_id} not found`);
-      }
-
-      if (!user2Data) {
-        throw new NotFoundException(`User with id ${user2_id} not found`);
-      }
-
       const collabInfoData: CollabInfoDto = {
         id: collabId,
 
@@ -364,12 +356,12 @@ export class CollaborationSupabase implements CollaborationRepository {
         ended_at: collab.ended_at,
 
         collab_user1: {
-          id: user1Data.id,
-          username: user1Data.username,
+          id: user1Data ? user1Data.id : null,
+          username: user1Data ? user1Data.username : 'DELETED USER',
         },
         collab_user2: {
-          id: user2Data.id,
-          username: user2Data.username,
+          id: user2Data ? user2Data.id : null,
+          username: user2Data ? user2Data.username : 'DELETED USER',
         },
         question: selectedQuestionData,
       };

--- a/project/apps/user-service/src/adapters/db/users.supabase.ts
+++ b/project/apps/user-service/src/adapters/db/users.supabase.ts
@@ -89,7 +89,7 @@ export class SupabaseUsersRepository implements UsersRepository {
       .from(this.PROFILES_TABLE)
       .select()
       .eq('id', id)
-      .single<UserDataDto>();
+      .maybeSingle<UserDataDto>();
 
     // for any unexpected error apart from null
     if (error && error.code != 'PGRST116') {

--- a/project/apps/user-service/src/adapters/db/users.supabase.ts
+++ b/project/apps/user-service/src/adapters/db/users.supabase.ts
@@ -92,7 +92,7 @@ export class SupabaseUsersRepository implements UsersRepository {
       .maybeSingle<UserDataDto>();
 
     // for any unexpected error apart from null
-    if (error && error.code != 'PGRST116') {
+    if (error) {
       throw error;
     }
 

--- a/project/apps/user-service/src/adapters/db/users.supabase.ts
+++ b/project/apps/user-service/src/adapters/db/users.supabase.ts
@@ -84,14 +84,15 @@ export class SupabaseUsersRepository implements UsersRepository {
     } as UserCollectionDto;
   }
 
-  async findById(id: string): Promise<UserDataDto> {
+  async findById(id: string): Promise<UserDataDto | null> {
     const { data, error } = await this.supabase
       .from(this.PROFILES_TABLE)
       .select()
       .eq('id', id)
       .single<UserDataDto>();
 
-    if (error) {
+    // for any unexpected error apart from null
+    if (error && error.code != 'PGRST116') {
       throw error;
     }
 
@@ -132,7 +133,7 @@ export class SupabaseUsersRepository implements UsersRepository {
 
   async updatePrivilegeById(id: string): Promise<UserDataDto> {
     const user = await this.findById(id);
-    const newRole = user.role == ROLE.Admin ? ROLE.User : ROLE.Admin;
+    const newRole = user!.role == ROLE.Admin ? ROLE.User : ROLE.Admin;
 
     // Update user role in profiles table
     const { data: updatedUser, error } = await this.supabase
@@ -164,16 +165,16 @@ export class SupabaseUsersRepository implements UsersRepository {
       throw authError;
     }
 
-    return await this.findById(changePasswordDto.id);
+    const updatedUser = await this.findById(changePasswordDto.id);
+    return updatedUser!;
   }
 
   async deleteById(id: string): Promise<boolean> {
-    // Delete user from profiles table first
-    const { data, error } = await this.supabase
+    // Delete user from profiles table first, else DB error since no cascade
+    const { error } = await this.supabase
       .from(this.PROFILES_TABLE)
       .delete()
-      .eq('id', id)
-      .single<UserDataDto>();
+      .eq('id', id);
 
     if (error) {
       throw error;
@@ -181,10 +182,11 @@ export class SupabaseUsersRepository implements UsersRepository {
 
     // Then delete user from auth table
     const { error: authError } = await this.supabase.auth.admin.deleteUser(id);
+
     if (authError) {
       throw authError;
     }
 
-    return data == null;
+    return true;
   }
 }

--- a/project/apps/user-service/src/domain/ports/users.repository.ts
+++ b/project/apps/user-service/src/domain/ports/users.repository.ts
@@ -23,7 +23,7 @@ export abstract class UsersRepository {
    * @param id - The unique identifier of the user.
    * @returns A promise that resolves to a UserDataDto object.
    */
-  abstract findById(id: string): Promise<UserDataDto>;
+  abstract findById(id: string): Promise<UserDataDto | null>;
 
   /**
    * Updates an existing user's details with the given data.
@@ -51,7 +51,7 @@ export abstract class UsersRepository {
   /**
    * Deletes an existing by its unique identifier.
    * @param id - The unique identifier of the user to be deleted.
-   * @returns A promise that resolves to a boolean indicating the success of the operation.
+   * @returns A promise that resolves to a UserDataDto indicating the success of the operation.
    */
   abstract deleteById(id: string): Promise<boolean>;
 }

--- a/project/apps/user-service/src/domain/ports/users.service.ts
+++ b/project/apps/user-service/src/domain/ports/users.service.ts
@@ -58,7 +58,7 @@ export class UsersService {
    * @returns {Promise<UserDataDto>} A promise that resolves to the user data transfer object.
    * @throws Will throw an error if the user cannot be fetched.
    */
-  async findById(id: string): Promise<UserDataDto> {
+  async findById(id: string): Promise<UserDataDto | null> {
     try {
       const user = await this.usersRepository.findById(id);
 
@@ -138,7 +138,7 @@ export class UsersService {
    * Deletes a user by their unique identifier.
    *
    * @param {string} id - The unique identifier of the user to be deleted.
-   * @returns {Promise<UserDataDto>} A promise that resolves to the deleted user data transfer object.
+   * @returns {Promise<boolean>} A promise that resolves to the deleted user data transfer object.
    * @throws Will throw an error if the user cannot be deleted.
    */
   async deleteById(id: string): Promise<boolean> {

--- a/project/apps/user-service/src/domain/ports/users.service.ts
+++ b/project/apps/user-service/src/domain/ports/users.service.ts
@@ -55,7 +55,7 @@ export class UsersService {
    * Fetches a user by their unique identifier.
    *
    * @param {string} id - The unique identifier of the user to be fetched.
-   * @returns {Promise<UserDataDto>} A promise that resolves to the user data transfer object.
+   * @returns {Promise<UserDataDto | null>} A promise that resolves to the user data transfer object if the user is found, else null.
    * @throws Will throw an error if the user cannot be fetched.
    */
   async findById(id: string): Promise<UserDataDto | null> {

--- a/project/apps/web/app/collab/[id]/page.tsx
+++ b/project/apps/web/app/collab/[id]/page.tsx
@@ -14,9 +14,9 @@ import CollabSkeleton from '@/components/collab/CollabSkeleton';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import { QUERY_KEYS } from '@/constants/queryKeys';
+import { getCollabInfoById } from '@/lib/api/collab';
 import { useAuthStore } from '@/stores/useAuthStore';
 import { useCollabStore } from '@/stores/useCollabStore';
-import { getCollabInfoById } from '@/lib/api/collab';
 
 interface CollabPageProps {
   params: {

--- a/project/apps/web/components/profile/ActionModals.tsx
+++ b/project/apps/web/components/profile/ActionModals.tsx
@@ -10,12 +10,14 @@ import { QUERY_KEYS } from '@/constants/queryKeys';
 import { useToast } from '@/hooks/use-toast';
 import { changePassword, deleteUser } from '@/lib/api/users';
 import { useProfileStore } from '@/stores/useProfileStore';
+import { useAuthStore } from '@/stores/useAuthStore';
 
 interface ActionModalsProps {
   user: UserDataDto;
 }
 
 export const ActionModals = ({ user }: ActionModalsProps) => {
+  const fetchUser = useAuthStore.use.fetchUser();
   const setConfirmLoading = useProfileStore.use.setConfirmLoading();
   const setChangePasswordModalOpen =
     useProfileStore.use.setChangePasswordModalOpen();
@@ -31,9 +33,6 @@ export const ActionModals = ({ user }: ActionModalsProps) => {
       changePassword(updatedPassword),
     onMutate: () => setConfirmLoading(true),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({
-        queryKey: [QUERY_KEYS.Question, user.id],
-      });
       await queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.Me] });
       setChangePasswordModalOpen(false);
       toast({
@@ -56,16 +55,13 @@ export const ActionModals = ({ user }: ActionModalsProps) => {
     mutationFn: (id: string) => deleteUser(id),
     onMutate: () => setConfirmLoading(true),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({
-        queryKey: [QUERY_KEYS.Me, user.id],
-      });
       await queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.Me] });
       setDeleteModalOpen(false);
-      router.replace('/'); // replace, not push, to disallow return to deleted user's profile
+      fetchUser();
       toast({
         variant: 'success',
         title: 'Success',
-        description: 'User deleted successfully',
+        description: 'Your account has been deleted successfully',
       });
     },
     onSettled: () => setConfirmLoading(false),

--- a/project/apps/web/components/profile/ActionModals.tsx
+++ b/project/apps/web/components/profile/ActionModals.tsx
@@ -2,15 +2,14 @@
 
 import { UserDataDto, ChangePasswordDto } from '@repo/dtos/users';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useRouter } from 'next/navigation';
 
 import ChangePasswordModal from '@/components/profile/ChangePasswordModal';
 import DeleteModal from '@/components/profile/DeleteModal';
 import { QUERY_KEYS } from '@/constants/queryKeys';
 import { useToast } from '@/hooks/use-toast';
 import { changePassword, deleteUser } from '@/lib/api/users';
-import { useProfileStore } from '@/stores/useProfileStore';
 import { useAuthStore } from '@/stores/useAuthStore';
+import { useProfileStore } from '@/stores/useProfileStore';
 
 interface ActionModalsProps {
   user: UserDataDto;
@@ -24,7 +23,6 @@ export const ActionModals = ({ user }: ActionModalsProps) => {
   const setDeleteModalOpen = useProfileStore.use.setDeleteModalOpen();
 
   const queryClient = useQueryClient();
-  const router = useRouter();
 
   const { toast } = useToast();
 

--- a/project/apps/web/components/profile/DeleteModal.tsx
+++ b/project/apps/web/components/profile/DeleteModal.tsx
@@ -28,7 +28,9 @@ export default function DeleteModal({ onDelete, username }: DeleteModalProps) {
           <DialogTitle>Delete Profile</DialogTitle>
         </DialogHeader>
         <DialogDescription>
-          <div>Are you sure you want to delete your account {username}?</div>
+          <div>Are you sure you want to delete your account, {username}?</div>
+          <div>All associated data will be permanently deleted.</div>
+          <br />
           <div>This action cannot be undone.</div>
         </DialogDescription>
         <DialogFooter>

--- a/project/apps/web/stores/useCollabStore.ts
+++ b/project/apps/web/stores/useCollabStore.ts
@@ -1,9 +1,9 @@
 import { CollabInfoDto } from '@repo/dtos/collab';
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 
 import { endCollab, getCollabInfoById } from '@/lib/api/collab';
 import { createSelectors } from '@/lib/zustand';
-import { persist } from 'zustand/middleware';
 
 interface CollabState {
   collaboration: CollabInfoDto | null;

--- a/project/packages/dtos/src/collab.ts
+++ b/project/packages/dtos/src/collab.ts
@@ -19,7 +19,7 @@ export const collabQuestionSchema = z.object({
 
 // Optional TODO: Do we want to also keep track of the number of question the user has done?
 export const collaboratorSchema = z.object({
-  id: z.string().uuid(),
+  id: z.string().uuid().nullable(),
   username: z.string(),
 });
 

--- a/project/packages/dtos/src/generated/types/collaboration.types.ts
+++ b/project/packages/dtos/src/generated/types/collaboration.types.ts
@@ -42,30 +42,33 @@ export type Database = {
         };
         Relationships: [];
       };
-      execution_snapshots: {
+      snapshots: {
         Row: {
-          colalboration_id: string;
-          created_at: string | null;
-          document: string | null;
+          code: string | null;
+          collaboration_id: string;
+          created_at: string;
+          id: string;
           output: string | null;
         };
         Insert: {
-          colalboration_id: string;
-          created_at?: string | null;
-          document?: string | null;
+          code?: string | null;
+          collaboration_id: string;
+          created_at?: string;
+          id?: string;
           output?: string | null;
         };
         Update: {
-          colalboration_id?: string;
-          created_at?: string | null;
-          document?: string | null;
+          code?: string | null;
+          collaboration_id?: string;
+          created_at?: string;
+          id?: string;
           output?: string | null;
         };
         Relationships: [
           {
-            foreignKeyName: "execution_snapshots_colalboration_id_fkey";
-            columns: ["colalboration_id"];
-            isOneToOne: true;
+            foreignKeyName: "snapshots_collaboration_id_fkey";
+            columns: ["collaboration_id"];
+            isOneToOne: false;
             referencedRelation: "collaboration";
             referencedColumns: ["id"];
           },

--- a/project/packages/dtos/src/generated/types/collaboration.types.ts
+++ b/project/packages/dtos/src/generated/types/collaboration.types.ts
@@ -42,6 +42,35 @@ export type Database = {
         };
         Relationships: [];
       };
+      execution_snapshots: {
+        Row: {
+          colalboration_id: string;
+          created_at: string | null;
+          document: string | null;
+          output: string | null;
+        };
+        Insert: {
+          colalboration_id: string;
+          created_at?: string | null;
+          document?: string | null;
+          output?: string | null;
+        };
+        Update: {
+          colalboration_id?: string;
+          created_at?: string | null;
+          document?: string | null;
+          output?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "execution_snapshots_colalboration_id_fkey";
+            columns: ["colalboration_id"];
+            isOneToOne: true;
+            referencedRelation: "collaboration";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
     };
     Views: {
       [_ in never]: never;

--- a/project/packages/dtos/src/generated/types/questions.types.ts
+++ b/project/packages/dtos/src/generated/types/questions.types.ts
@@ -44,27 +44,27 @@ export type Database = {
       };
       test_cases: {
         Row: {
+          cases: Json;
           created_at: string | null;
-          expected_output: string;
           id: string;
-          input: Json;
-          question_id: string | null;
+          question_id: string;
+          schema: Json;
           updated_at: string | null;
         };
         Insert: {
+          cases: Json;
           created_at?: string | null;
-          expected_output: string;
           id?: string;
-          input: Json;
-          question_id?: string | null;
+          question_id: string;
+          schema: Json;
           updated_at?: string | null;
         };
         Update: {
+          cases?: Json;
           created_at?: string | null;
-          expected_output?: string;
           id?: string;
-          input?: Json;
-          question_id?: string | null;
+          question_id?: string;
+          schema?: Json;
           updated_at?: string | null;
         };
         Relationships: [

--- a/project/packages/dtos/src/generated/types/questions.types.ts
+++ b/project/packages/dtos/src/generated/types/questions.types.ts
@@ -42,6 +42,48 @@ export type Database = {
         };
         Relationships: [];
       };
+      test_cases: {
+        Row: {
+          created_at: string | null;
+          expected_output: string;
+          id: string;
+          input: Json;
+          question_id: string | null;
+          updated_at: string | null;
+        };
+        Insert: {
+          created_at?: string | null;
+          expected_output: string;
+          id?: string;
+          input: Json;
+          question_id?: string | null;
+          updated_at?: string | null;
+        };
+        Update: {
+          created_at?: string | null;
+          expected_output?: string;
+          id?: string;
+          input?: Json;
+          question_id?: string | null;
+          updated_at?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "test_cases_question_id_fkey";
+            columns: ["question_id"];
+            isOneToOne: false;
+            referencedRelation: "question_bank";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "test_cases_question_id_fkey";
+            columns: ["question_id"];
+            isOneToOne: false;
+            referencedRelation: "random_question";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
     };
     Views: {
       random_question: {


### PR DESCRIPTION
## Changes Made
- `getCollabs` handles null users in event that user is deleted (`get_users` will return null as `uid` not present in `profiles` table)
- History will show 'DELETED USER' as username for users who previously collaborated with the deleted user
- Minor fix to delete user endpoint and FE to fetch on success
- On delete, user entry in profiles table will be deleted entirely -> user can recreate with same email but start afresh